### PR TITLE
Unique task IDs using UUID.

### DIFF
--- a/src/main/java/com/sunybingcloud/felk/config/task/TaskUtils.java
+++ b/src/main/java/com/sunybingcloud/felk/config/task/TaskUtils.java
@@ -16,6 +16,7 @@ package com.sunybingcloud.felk.config.task;
 import org.apache.mesos.Protos;
 
 import java.util.Collection;
+import java.util.UUID;
 
 public final class TaskUtils {
     public static final class TaskIdGenerator {
@@ -27,8 +28,7 @@ public final class TaskUtils {
          * @return a unique identifier for the task.
          */
         static String createTaskID(final String taskName, final int instance) {
-            // This is a very naive way of creating identifiers.
-            return "Felk-" + taskName + "-" + instance;
+            return "Felk-" + taskName + "-" + instance + "-" + UUID.randomUUID().toString();
         }
 
         /**


### PR DESCRIPTION
Earlier, if the workload contained multiple task JSON objects with
the same name, then the task IDs for instance N would be the same
for both the tasks. The reason for this was that task IDs were
created as `Felk-<task_name>-<task_instance>`.
Fixed this issue by appending UUID. So, the new task IDs are
`Felk-<task_name>-<task_instance>-<uuid>`